### PR TITLE
make sure to return an array even when there is no data

### DIFF
--- a/src/Helpers/MicroServiceHelper.php
+++ b/src/Helpers/MicroServiceHelper.php
@@ -81,10 +81,15 @@ class MicroServiceHelper
         $response->code = $code;
         $response->message = $message;
 
-        // Only add the data if supplied.
+        // Return data in an array.
         if (!empty($data)) {
             $response->data = new stdClass();
             $response->data->{$type} = $data;
+        }
+        else {
+            // Return an empty array even if there are no data.
+            $response->data = new stdClass();
+            $response->data->{$type} = [];
         }
 
         return $response;


### PR DESCRIPTION
When passing empty data to response jsonResponseFormatter make sure we return them back as an empty array.